### PR TITLE
Match the python version pinning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9]
+        # TODO: Re-implement pulling this version from the repo version
+        python-version: [3.9.15]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
When pulling in pants, I pinned the patch python version within pants itself, but did not pin it within the CI. This fixes that.